### PR TITLE
Change data format when loading GML data

### DIFF
--- a/R/read-rrs-map.R
+++ b/R/read-rrs-map.R
@@ -10,107 +10,137 @@
 #'   of 1000 to match the simulation environment, and adjusted such that
 #'   the minimum x and y values are 0. (Default: `TRUE`)
 #' @return A list of `sf` objects: nodes, edges, buildings, and roads.
+#'   Also includes a sub-list `raw_parsed_data` containing the intermediate
+#'   data frames from XML parsing.
 #' @examples
 #' gml <- system.file("extdata", "map-test.gml", package = "rrstools")
 #' map_data <- read_rrs_map(gml)
 #' map_data
 NULL
 
-# Parse nodes from the XML and return a sf object
-parse_nodes <- function(xml, scale_data) {
+# Extract href attribute from an feature element
+extract_href_value <- function(feature) {
+  sub("#", "", xml2::xml_attr(feature, "href"))
+}
+
+# Parse node data from XML content
+parse_nodes <- function(xml) {
   nodes <- xml2::xml_find_all(xml, ".//gml:Node")
   coordinates <- strsplit(xml2::xml_text(nodes), ",")
 
-  x <- as.numeric(sapply(coordinates, "[[", 1))
-  y <- as.numeric(sapply(coordinates, "[[", 2))
-  if (scale_data) {
-    x <- x * 1000
-    y <- y * 1000
-    x <- x - min(x)
-    y <- y - min(y)
-  }
-
-  return(sf::st_as_sf(
-    data.frame(id = xml2::xml_attr(nodes, "id"), x, y),
-    coords = c("x", "y"), crs = NA, agr = "constant"
-  ))
+  data.frame(
+    id = xml2::xml_attr(nodes, "id"),
+    x = as.numeric(sapply(coordinates, "[[", 1)),
+    y = as.numeric(sapply(coordinates, "[[", 2))
+  )
 }
 
-# Extract node references and orientations from edges
-extract_edge_nodes <- function(edges) {
+# Parse edge data from XML content
+parse_edges <- function(xml) {
+  edges <- xml2::xml_find_all(xml, ".//gml:Edge")
   directed_nodes <- xml2::xml_find_all(edges, ".//gml:directedNode")
-  node_ref <- sub("^#", "", xml2::xml_attr(directed_nodes, "href"))
+  node_hrefs <- extract_href_value(directed_nodes)
   orientations <- xml2::xml_attr(directed_nodes, "orientation")
 
-  return(list(
-    source = node_ref[orientations == "+"],
-    target = node_ref[orientations == "-"]
-  ))
+  data.frame(
+    id = xml2::xml_attr(edges, "id"),
+    start_node_id = node_hrefs[orientations == "-"],
+    end_node_id = node_hrefs[orientations == "+"]
+  )
 }
 
-# Parse edges and create a sf object
-parse_edges <- function(xml, node_sf) {
-  edges <- xml2::xml_find_all(xml, ".//gml:Edge")
-  edge_nodes <- extract_edge_nodes(edges)
+# Parse face (building/road) data from XML content
+parse_faces <- function(xml) {
+  features <- xml2::xml_find_all(xml, ".//rcr:building|.//rcr:road")
+  faces <- xml2::xml_find_all(features, ".//gml:Face")
+  direct_edges <- xml2::xml_find_all(faces, ".//gml:directedEdge")
 
-  source_nodes <- node_sf$geometry[match(edge_nodes$source, node_sf$id)]
-  target_nodes <- node_sf$geometry[match(edge_nodes$target, node_sf$id)]
+  data.frame(
+    id = rep(xml2::xml_attr(features, "id"), xml2::xml_length(faces)),
+    type = rep(xml2::xml_name(features), xml2::xml_length(faces)),
+    orientation = xml2::xml_attr(direct_edges, "orientation"),
+    edge_hrefs = extract_href_value(direct_edges),
+    neighbour = xml2::xml_attr(direct_edges, "neighbour")
+  )
+}
 
+# Create an sf object (POINTs) for nodes from node data
+create_node_sf <- function(nodes, scale_data) {
+  if (scale_data) {
+    x <- nodes$x * 1000
+    y <- nodes$y * 1000
+    x <- x - min(x)
+    y <- y - min(y)
+  } else {
+    x <- nodes$x
+    y <- nodes$y
+  }
+
+  sf::st_as_sf(
+    data.frame(id = nodes$id, x = x, y = y),
+    coords = c("x", "y"), crs = NA, agr = "constant"
+  )
+}
+
+# Create an sf object (LINESTRINGs) for nodes from edge data
+create_edge_sf <- function(edges, node_sf) {
+  source_nodes <- node_sf$geometry[match(edges$start_node_id, node_sf$id)]
+  target_nodes <- node_sf$geometry[match(edges$end_node_id, node_sf$id)]
   geometries <- mapply(
     function(p1, p2) sf::st_linestring(c(p1, p2)),
     source_nodes, target_nodes, SIMPLIFY = FALSE
   )
 
-  return(sf::st_sf(
-    id = xml2::xml_attr(edges, "id"),
+  sf::st_sf(
+    id = edges$id,
     geometry = geometries, crs = NA, agr = "constant"
-  ))
+  )
 }
 
-# Group and combine edges for buildings or roads
-group_edges_by_face <- function(edges, faces) {
-  direct_edges <- xml2::xml_find_all(faces, ".//gml:directedEdge")
-  edge_ids <- sub("^#", "", xml2::xml_attr(direct_edges, "href"))
-  matched_edges <- edges$geometry[match(edge_ids, edges$id)]
-  group_indices <- rep(seq_along(faces), xml2::xml_length(faces))
+# Create an sf object (POLYGONs) for nodes from face data
+create_face_sf <- function(faces, edge_sf) {
+  face_list <- lapply(split(faces, faces$id), function(face) {
+    edge_ids <- face$edge_hrefs
+    lines <- edge_sf$geometry[match(edge_ids, edge_sf$id)]
+    poligonized_face <- sf::st_polygonize(sf::st_union(lines))
 
-  return(split(matched_edges, group_indices))
-}
-
-# Parse faces (building or roads) and create a sf object
-parse_faces <- function(xml, edge_sf, type = c("building", "road")) {
-  type <- match.arg(type)
-  features <- xml2::xml_find_all(xml, paste0(".//rcr:", type))
-  faces <- xml2::xml_find_all(features, ".//gml:Face")
-  edge_groups <- group_edges_by_face(edge_sf, faces)
-
-  geometries <- sapply(edge_groups, function(lines) {
-    combined_lines <- sf::st_union(lines)
-    sf::st_collection_extract(sf::st_polygonize(combined_lines), "POLYGON")
+    sf::st_sf(
+      id = face$id[1],
+      type = face$type[1],
+      geometry = sf::st_collection_extract(poligonized_face, "POLYGON")
+    )
   })
 
-  return(sf::st_sf(
-    id = xml2::xml_attr(features, "id"),
-    geometry = geometries, crs = NA, agr = "constant"
-  ))
+  sf::st_set_agr(do.call(rbind, face_list), "constant")
 }
 
 # Read a GML map and extract nodes, edges, buildings, and roads
 #' @rdname read_rrs_map
 #' @export
 read_rrs_map <- function(gml, scale_data = FALSE) {
+  # Load the XML structure from the GML file
   xml <- xml2::read_xml(gml)
 
-  node_sf <- parse_nodes(xml, scale_data)
-  edge_sf <- parse_edges(xml, node_sf)
-  building_sf <- parse_faces(xml, edge_sf, "building")
-  road_sf <- parse_faces(xml, edge_sf, "road")
+  # Extract raw data from XML structure
+  nodes <- parse_nodes(xml)
+  edges <- parse_edges(xml)
+  faces <- parse_faces(xml)
+
+  # Create sf Objects
+  node_sf <- create_node_sf(nodes, scale_data)
+  edge_sf <- create_edge_sf(edges, node_sf)
+  face_sf <- create_face_sf(faces, edge_sf)
 
   rrs_map <- list(
-    nodes = node_sf,
-    edges = edge_sf,
-    buildings = building_sf,
-    roads = road_sf
+    node_sf         = node_sf,
+    edge_sf         = edge_sf,
+    building_sf     = face_sf[face_sf$type == "building", "id"],
+    road_sf         = face_sf[face_sf$type == "road", "id"],
+    raw_parsed_data = list(
+      nodes = nodes,
+      edges = edges,
+      faces = faces
+    )
   )
   class(rrs_map) <- c("rrs_map", "list")
 

--- a/R/rrs-map.R
+++ b/R/rrs-map.R
@@ -22,13 +22,13 @@ plot.rrs_map <- function(x,
                          ...) {
   graphics::par(...)
   plot(
-    x$buildings$geometry,
+    x$building_sf$geometry,
     col    = building_colour,
     border = building_border,
     bg     = background_colour
   )
   plot(
-    x$roads$geometry,
+    x$road_sf$geometry,
     col    = road_colour,
     border = road_border,
     add    = TRUE

--- a/man/read_rrs_map.Rd
+++ b/man/read_rrs_map.Rd
@@ -15,6 +15,8 @@ the minimum x and y values are 0. (Default: \code{TRUE})}
 }
 \value{
 A list of \code{sf} objects: nodes, edges, buildings, and roads.
+Also includes a sub-list \code{raw_parsed_data} containing the intermediate
+data frames from XML parsing.
 }
 \description{
 This function reads and processes map data for RoboCupRescue Simulation

--- a/rrstools.Rproj
+++ b/rrstools.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: bc0294c1-8669-4cf4-8bc0-b5f9b4fc7d14
 
 RestoreWorkspace: No
 SaveWorkspace: No


### PR DESCRIPTION
Modified the data structure so that not only the outline but also information such as object dependencies and other parsed details retain most of the information from the original GML data. This change resolves Issue #3.